### PR TITLE
Typo fix

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -51,6 +51,6 @@ runs:
         # Set outputs
         open(ENV["GITHUB_OUTPUT"], "a") do io
           println(io, "total=$(inv_total)")
-          println(io, "deps=$(inv_deps)")'
+          println(io, "deps=$(inv_deps)")
         end
       shell: julia --color=yes --project=. {0}    


### PR DESCRIPTION
Found in https://github.com/JuliaArrays/StructArrays.jl/pull/215 with
```julia
ERROR: LoadError: MethodError: no method matching adjoint(::Nothing)
Closest candidates are:
  adjoint(::Union{LinearAlgebra.QR, LinearAlgebra.QRCompactWY, LinearAlgebra.QRPivoted}) at /opt/hostedtoolcache/julia/1.8.2/x64/share/julia/stdlib/v1.8/LinearAlgebra/src/qr.jl:517
  adjoint(::Union{LinearAlgebra.Cholesky, LinearAlgebra.CholeskyPivoted}) at /opt/hostedtoolcache/julia/1.8.2/x64/share/julia/stdlib/v1.8/LinearAlgebra/src/cholesky.jl:558
  adjoint(::LinearAlgebra.Hermitian) at /opt/hostedtoolcache/julia/1.8.2/x64/share/julia/stdlib/v1.8/LinearAlgebra/src/symmetric.jl:348
  ...
```
@SaschaMann