### PR TITLE
Print invalidations summary

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ runs:
       shell: bash
       
     - name: Install SnoopCompile tools
-      run: julia --project -e 'using Pkg; Pkg.add(["SnoopCompileCore", "SnoopCompile"])'
+      run: julia --project -e 'using Pkg; Pkg.add(["SnoopCompileCore", "SnoopCompile", "PrettyTables"])'
       shell: bash
     - name: Load package on branch
       id: invs
@@ -47,6 +47,14 @@ runs:
         inv_deps = inv_total - inv_owned
         
         @show inv_total, inv_deps
+
+        # Report invalidations summary:
+        using PrettyTables  # needed for `report_invalidations` to be defined
+        SnoopCompile.report_invalidations(;
+             invalidations,
+             process_filename = x -> last(split(x, ".julia/packages/")),
+             n_rows = 0,  # no-limit (show all invalidations)
+        )
 
         # Set outputs
         open(ENV["GITHUB_OUTPUT"], "a") do io


### PR DESCRIPTION
This PR adds a call to SnoopCompile's `report_invalidations`, which tabulates a summary of the invalidations (described here: https://timholy.github.io/SnoopCompile.jl/dev/tutorial/#Cut-to-the-Chase:-A-copy-paste-analysis-of-invalidations). I think this may be useful to users, in addition to just the number of invalidations?

Closes #12.