### PR TITLE
Adapt to SnoopCompile v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # julia-invalidations
-Uses [`SnoopCompile.@snoopr`](https://timholy.github.io/SnoopCompile.jl/stable/snoopr/)
+Uses [`SnoopCompile.@snoop_invalidations`](https://timholy.github.io/SnoopCompile.jl/stable/reference/#SnoopCompileCore.@snoop_invalidations)
 to evaluate number of invalidations caused by `using Package` or a provided script
 
 

--- a/action.yml
+++ b/action.yml
@@ -31,7 +31,7 @@ runs:
           fi
           echo "testscript=$TESTSCRIPT" >> $GITHUB_OUTPUT
       shell: bash
-      
+
     - name: Install SnoopCompile tools
       run: julia --project -e 'using Pkg; Pkg.add(["SnoopCompileCore", "SnoopCompile", "PrettyTables"])'
       shell: bash
@@ -39,13 +39,13 @@ runs:
       id: invs
       run: |
         using SnoopCompileCore
-        invalidations = @snoopr begin ${{ steps.info.outputs.testscript }} end
-        
+        invalidations = @snoop_invalidations begin ${{ steps.info.outputs.testscript }} end
+
         using SnoopCompile
         inv_owned = length(filtermod(${{ steps.info.outputs.packagename }}, invalidation_trees(invalidations)))
         inv_total = length(uinvalidated(invalidations))
         inv_deps = inv_total - inv_owned
-        
+
         @show inv_total, inv_deps
 
         # Report invalidations summary:
@@ -61,4 +61,4 @@ runs:
           println(io, "total=$(inv_total)")
           println(io, "deps=$(inv_deps)")
         end
-      shell: julia --color=yes --project=. {0}    
+      shell: julia --color=yes --project=. {0}


### PR DESCRIPTION
Closes #18 (I think).

The fix was pretty simple: `@snoopr` was renamed to `@snoop_invalidations` (see [NEWS.md](https://github.com/timholy/SnoopCompile.jl/blob/master/NEWS.md#version-3)).