### PR TITLE
Specifically install SnoopCompile v2 (and thus prevent the breakage from SnoopCompile v3)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -33,8 +33,15 @@ runs:
       shell: bash
       
     - name: Install SnoopCompile tools
-      run: julia --project -e 'using Pkg; Pkg.add(["SnoopCompileCore", "SnoopCompile", "PrettyTables"])'
-      shell: bash
+      run: |
+        import Pkg;
+        pkgs = [
+            Pkg.PackageSpec(name = "SnoopCompile", version = "2"),
+            Pkg.PackageSpec(name = "SnoopCompileCore"),
+            Pkg.PackageSpec(name = "PrettyTables"),
+        ]
+        Pkg.add(pkgs)
+      shell: julia --project
     - name: Load package on branch
       id: invs
       run: |


### PR DESCRIPTION
This is the immediate fix to the breakage from SnoopCompile v3.

This PR avoids us needing to change the minimum supported Julia version.