### PR TITLE
Specify UUIDs when installing packages

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -36,9 +36,9 @@ runs:
       run: |
         import Pkg;
         pkgs = [
-            Pkg.PackageSpec(name = "SnoopCompile", version = "2"),
-            Pkg.PackageSpec(name = "SnoopCompileCore"),
-            Pkg.PackageSpec(name = "PrettyTables"),
+            Pkg.PackageSpec(name = "SnoopCompile", version = "2", uuid = "aa65fe97-06da-5843-b5b1-d5d13cad87d2"),
+            Pkg.PackageSpec(name = "SnoopCompileCore", uuid = "e2b509da-e806-4183-be48-004708413034"),
+            Pkg.PackageSpec(name = "PrettyTables", uuid = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"),
         ]
         Pkg.add(pkgs)
       shell: julia --project {0}


### PR DESCRIPTION
This future-proofs this action against a hypothetical (and very unlikely) future in which multiple packages would be allowed to have the same name.