### PR TITLE
Add the `package_name` input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,10 @@ inputs:
     description: 'Script to test for invalidations. Defaults to `using Package`'
     required: false
     default: ''
+  package_name:
+    description: 'Name of the package. By default, tries to auto-detect from the repo name.'
+    required: false
+    default: ''
 
 outputs:
   total: 
@@ -22,7 +26,12 @@ runs:
       id: info
       run: |
           REPONAME="${{ github.event.repository.name }}"
-          PACKAGENAME=${REPONAME%.jl}
+          if [[ '${{ inputs.package_name }}' == '' ]]; then
+            PACKAGENAME=${REPONAME%.jl}
+          else
+            PACKAGENAME=""
+            PACKAGENAME="${{ inputs.package_name }}"
+          fi
           echo "packagename=$PACKAGENAME" >> $GITHUB_OUTPUT
           if [[ '${{ inputs.test_script }}' == '' ]]; then
             TESTSCRIPT="using ${PACKAGENAME}"

--- a/action.yml
+++ b/action.yml
@@ -29,7 +29,6 @@ runs:
           if [[ '${{ inputs.package_name }}' == '' ]]; then
             PACKAGENAME=${REPONAME%.jl}
           else
-            PACKAGENAME=""
             PACKAGENAME="${{ inputs.package_name }}"
           fi
           echo "packagename=$PACKAGENAME" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Currently, this action assumes that the repo is named `PackageName.jl`. If the repo does not match that naming convention, currently this action breaks, with no workaround.

This PR adds the `package_name` input, which allows the user to manually specify the package name if the repo is not named `PackageName.jl`.